### PR TITLE
feat: add question counters on List view

### DIFF
--- a/client/src/List.svelte
+++ b/client/src/List.svelte
@@ -287,6 +287,7 @@
 	{/if}
 
 	<section class="pt-4">
+	<h2 class="mb-4 text-lg text-slate-400 text-right">({unanswered.length} / {answered.length + unanswered.length})</h2>
 	{#if unanswered.length > 0}
 		<div class="flex flex-col divide-y">
 		{#each unanswered as question (question.qid)}
@@ -307,7 +308,9 @@
 	</section>
 	{#if answered.length > 0}
 	<section>
-	<h2 class="text-2xl text-center text-green-700 dark:text-lime-500 mt-8 mb-4">Answered</h2>
+	<h2 class="text-2xl text-center text-green-700 dark:text-lime-500 mt-8 mb-4">Answered
+		<span class="text-lg float-right">({answered.length} / {answered.length + unanswered.length})</span>
+	</h2>
 	<div class="flex flex-col divide-y">
 	{#each answered as question (question.qid)}
 		<div animate:flip="{{duration: 500}}">

--- a/client/src/List.svelte
+++ b/client/src/List.svelte
@@ -287,7 +287,6 @@
 	{/if}
 
 	<section class="pt-4">
-	<h2 class="mb-4 text-lg text-slate-400 text-right">({unanswered.length} / {answered.length + unanswered.length})</h2>
 	{#if unanswered.length > 0}
 		<div class="flex flex-col divide-y">
 		{#each unanswered as question (question.qid)}


### PR DESCRIPTION
At the end of the last stream you mentioned it would be nice to add counters for the number of answered/unanswered question. Thought I'd save you a little time and implement it. Below is a screenshot of of the page (host and viewer).

<img width="1792" alt="Screenshot 2022-12-03 at 2 52 34 PM" src="https://user-images.githubusercontent.com/11818566/205463698-cf047f76-da88-4d48-bf34-c28275a08956.png">

### Side Question: 

I've noticed that most of your Q/A videos have great chapters/timestamps info. I was wondering if this is a manual process or if they are automatically generated by youtube? 

If it's a manual process, I thought it could be fun/useful to write a small application to autogenerate them using youtube's audio along with question data from wewerewondering. It could use a text-to-speech library to find timestamp matches from the audio and generate the chapters automatically. 