### PR TITLE
Allow negative votes in both backends

### DIFF
--- a/server/src/vote.rs
+++ b/server/src/vote.rs
@@ -50,7 +50,7 @@ impl Backend {
                     .get_mut(qid)
                     .expect("voting for non-existing question");
                 if let Some(AttributeValue::N(n)) = q.get_mut("votes") {
-                    let real_n = n.parse::<usize>().expect("votes values are numbers");
+                    let real_n = n.parse::<isize>().expect("votes values are numbers");
                     let new_n = match direction {
                         UpDown::Up => real_n + 1,
                         UpDown::Down => real_n - 1,


### PR DESCRIPTION
Earlier, when playing around with the app locally, I encountered a panic subtracting a vote when the count was already zero. Could not reliably reproduce it, but this [is](https://github.com/jonhoo/wewerewondering/blob/e7798f6abcc10b24ba9ff7a395cf64f3f227c175/server/src/vote.rs#L56) actually possible.

The other option would be to disallow negative votes in both places, please see an alternative pr