### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,6 +41,20 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --check --manifest-path server/Cargo.toml
         run: cargo fmt --check
+  in_release_mode_on_arm:
+    runs-on: ubuntu-latest
+    name: stable / release-arm
+    defaults:
+      run:
+        working-directory: ./server
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+      - name: cargo check --release --target aarch64-unknown-linux-gnu
+        run: cargo check --release --target aarch64-unknown-linux-gnu
   clippy:
     runs-on: ubuntu-latest
     name: ${{ matrix.toolchain }} / clippy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,15 +47,15 @@ jobs:
       run:
         working-directory: ./server
     steps:
-      - name: Install aarch64-gcc
-        run: sudo apt-get install gcc-aarch64-linux-gnu
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: rustup target add aarch64-unknown-linux-gnu
         run: rustup target add aarch64-unknown-linux-gnu
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
+      - name: Install aarch64-gcc
+        run: sudo apt-get install gcc-aarch64-linux-gnu
       - name: cargo check --release --target aarch64-unknown-linux-gnu
         run: cargo check --release --target aarch64-unknown-linux-gnu
   clippy:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,15 +47,15 @@ jobs:
       run:
         working-directory: ./server
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
+      - name: Install aarch64-gcc
+        run: sudo apt-get install gcc-aarch64-linux-gnu
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: rustup target add aarch64-unknown-linux-gnu
         run: rustup target add aarch64-unknown-linux-gnu
-      - name: Install aarch64-gcc
-        run: apt install gcc-aarch64-linux-gnu
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: cargo check --release --target aarch64-unknown-linux-gnu
         run: cargo check --release --target aarch64-unknown-linux-gnu
   clippy:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           components: rustfmt
       - name: cargo fmt --check
-        run: cargo fmt --check --manifest-path server/Cargo.toml
         run: cargo fmt --check
   in_release_mode_on_arm:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,6 +52,8 @@ jobs:
           submodules: true
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
+      - name: rustup target add aarch64-unknown-linux-gnu
+        run: rustup target add aarch64-unknown-linux-gnu
       - name: cargo check --release --target aarch64-unknown-linux-gnu
         run: cargo check --release --target aarch64-unknown-linux-gnu
   clippy:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,8 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: rustup target add aarch64-unknown-linux-gnu
         run: rustup target add aarch64-unknown-linux-gnu
+      - name: Install aarch64-gcc
+        run: apt install gcc-aarch64-linux-gnu
       - name: cargo check --release --target aarch64-unknown-linux-gnu
         run: cargo check --release --target aarch64-unknown-linux-gnu
   clippy:

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -167,7 +167,10 @@ async fn main() -> Result<(), Error> {
         .with_env_filter(EnvFilter::from_default_env())
         .without_time(/* cloudwatch does that */).init();
 
-    let backend = if !cfg!(debug_assertions) || std::env::var_os("USE_DYNAMODB").is_some() {
+    #[cfg(not(debug_assertions))]
+    let backend = Backend::dynamo().await;
+    #[cfg(debug_assertions)]
+    let backend = if std::env::var_os("USE_DYNAMODB").is_some() {
         Backend::dynamo().await
     } else {
         use rand::prelude::SliceRandom;


### PR DESCRIPTION
PR #179 broke release builds by making it necessary for `LiveAskQuestion` and `SEED` to both now be available regardless of whether `debug_assertions` is set. That's unfortunate, since `SEED` in particular would make the binary quite large. So I've instead made it so that in release mode (or rather, without `debug_assertions`), `SEED` is _not_ compiled in, and DynamoDB mode is _always_ used.

I've also added a CI job to check `--release --target aarch64-unknown-linux-gnu` so that this can't happen in the future.