### PR TITLE
Surface questions over a given threshold

### DIFF
--- a/server/src/list.rs
+++ b/server/src/list.rs
@@ -252,7 +252,9 @@ async fn list_inner(
             questions.sort_by_key(|item| {
                 std::cmp::Reverse(item["votes"].as_u64().expect("votes is a number"))
             });
-            questions[TOP_N..].sort_by_cached_key(|q| std::cmp::Reverse(score(q)));
+            if let Some(subslice) = questions.get_mut(TOP_N..) {
+                subslice.sort_by_cached_key(|q| std::cmp::Reverse(score(q)));
+            }
             questions.append(&mut answered_hidden);
             let max_age = if has_secret {
                 // hosts should be allowed to see more up-to-date views

--- a/server/src/list.rs
+++ b/server/src/list.rs
@@ -294,23 +294,6 @@ async fn list_inner(
     }
 }
 
-fn top_n_sort<T: std::cmp::Ord + std::cmp::Eq + Default>(vec: &mut Vec<T>, top: usize) {
-    for i in 1..vec.len() {
-        let high = top.min(i);
-        if vec[high - 1] > vec[i] {
-            continue;
-        }
-        let key = vec.remove(i);
-        let mut pos = vec[..high]
-            .binary_search_by(|e| key.cmp(e))
-            .unwrap_or_else(|pos| pos);
-        if pos == high {
-            pos -= 1;
-        }
-        vec.insert(pos, key);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Proposed fix for https://github.com/jonhoo/wewerewondering/issues/212.

Adding a top n sort function for all questions. The top votes which are unanswered and not hidden will be ranked first.
And the rest are sorted by the current hotness score.