### PR TITLE
Fix tailwindcss import

### DIFF
--- a/client/src/App.svelte
+++ b/client/src/App.svelte
@@ -106,7 +106,5 @@
 {/if}
 
 <style global lang="postcss">
-	@tailwind utilities;
-	@tailwind components;
-	@tailwind base;
+	@import "tailwindcss";
 </style>


### PR DESCRIPTION
We now need to import `tailwindcss` in a [different](https://tailwindcss.com/docs/upgrade-guide#removed-tailwind-directives) manner.

They also encourage us to use a [dedicated](https://tailwindcss.com/docs/upgrade-guide#using-vite) vite integration, which should be a subject of a dedicated PR, if we opt for it.

