### PR TITLE
Add database checks in end-to-end tests 

### DIFF
--- a/server/tests/e2e/answer.rs
+++ b/server/tests/e2e/answer.rs
@@ -251,7 +251,7 @@ async fn guest_asks_question_and_host_hides_it(
     // just like in the "answer" scenario, let's wait until the changes
     // are sent to the server and synced back
     g1.wait_for_polling().await;
-    // they skill see their "question" on the screen even though it has been
+    // they still see their "question" on the screen even though it has been
     // hidden by the host (later in this test we are demonstrating that the
     // question gets hidden from _other_ guests)
     let pending = h.expect_questions(QuestionState::Hidden).await.unwrap();

--- a/server/tests/e2e/answer.rs
+++ b/server/tests/e2e/answer.rs
@@ -6,7 +6,7 @@ async fn guest_asks_question_and_host_answers(
         host: h,
         guest1: g1,
         guest2: g2,
-        ..
+        dynamo: d,
     }: TestContext,
 ) {
     // ------------------------ host window ----------------------------------
@@ -14,6 +14,11 @@ async fn guest_asks_question_and_host_answers(
     let guest_url = h.create_event().await;
     // initially no questions
     assert!(h.expect_questions(QuestionState::Pending).await.is_err());
+
+    // -------------------------- database -----------------------------------
+    // sanity check: we do not have any questions for this event in db
+    let event_id = guest_url.path_segments().unwrap().next_back().unwrap();
+    assert_eq!(d.event_questions(event_id).await.unwrap().count, 0);
 
     // ------------------------ guest window ---------------------------------
     // guest opens the link and ...
@@ -150,7 +155,7 @@ async fn guest_asks_question_and_host_hides_it(
         host: h,
         guest1: g1,
         guest2: g2,
-        ..
+        dynamo: d,
     }: TestContext,
 ) {
     // ------------------------ host window ----------------------------------
@@ -158,6 +163,11 @@ async fn guest_asks_question_and_host_hides_it(
     let guest_url = h.create_event().await;
     // initially no questions
     assert!(h.expect_questions(QuestionState::Pending).await.is_err());
+
+    // -------------------------- database -----------------------------------
+    // sanity check: we do not have any questions for this event in db
+    let event_id = guest_url.path_segments().unwrap().next_back().unwrap();
+    assert_eq!(d.event_questions(event_id).await.unwrap().count, 0);
 
     // ---------------- first guest (not a gentle person) window -------------
     // guest opens the link and ...

--- a/server/tests/e2e/answer.rs
+++ b/server/tests/e2e/answer.rs
@@ -251,6 +251,17 @@ async fn guest_asks_question_and_host_hides_it(
     // just like in the "answer" scenario, let's wait until the changes
     // are sent to the server and synced back
     g1.wait_for_polling().await;
+    // they skill see their "question" on the screen even though it has been
+    // hidden by the host (later in this test we are demonstrating that the
+    // question gets hidden from _other_ guests)
+    let pending = h.expect_questions(QuestionState::Hidden).await.unwrap();
+    assert_eq!(pending.len(), 1);
+    assert!(pending[0]
+        .text()
+        .await
+        .unwrap()
+        .to_lowercase()
+        .contains(&qtext.to_lowercase()));
     // NB: the host would see these questions in the hidden as tested above
     assert!(g1.expect_questions(QuestionState::Hidden).await.is_err());
 

--- a/server/tests/e2e/answer.rs
+++ b/server/tests/e2e/answer.rs
@@ -11,18 +11,17 @@ async fn guest_asks_question_and_host_answers(
 ) {
     // ------------------------ host window ----------------------------------
     // host creates a new event
-    let guest_url = h.create_event().await;
+    let (eid, url) = h.create_event().await;
     // initially no questions
     assert!(h.expect_questions(QuestionState::Pending).await.is_err());
 
     // -------------------------- database -----------------------------------
     // sanity check: we do not have any questions for this event in db
-    let event_id = guest_url.path_segments().unwrap().next_back().unwrap();
-    assert_eq!(d.event_questions(event_id).await.unwrap().count, 0);
+    assert_eq!(d.event_questions(eid).await.unwrap().count, 0);
 
     // ------------------------ guest window ---------------------------------
     // guest opens the link and ...
-    g1.goto(guest_url.as_str()).await.unwrap();
+    g1.goto(url.as_str()).await.unwrap();
     // ... asks a question, which ...
     let (qtext, qauthor) = (
         "Did you attend Rust Forge conference in Wellington in 2025?",
@@ -42,7 +41,7 @@ async fn guest_asks_question_and_host_answers(
 
     // ------------------------ second guest window ----------------------
     // second guest can also see the question
-    g2.goto(guest_url.as_str()).await.unwrap();
+    g2.goto(url.as_str()).await.unwrap();
     let pending = g2.expect_questions(QuestionState::Pending).await.unwrap();
     assert_eq!(pending.len(), 1);
     assert!(pending[0]
@@ -160,13 +159,12 @@ async fn guest_asks_question_and_host_hides_it(
 ) {
     // ------------------------ host window ----------------------------------
     // host creates a new event
-    let guest_url = h.create_event().await;
+    let (event_id, guest_url) = h.create_event().await;
     // initially no questions
     assert!(h.expect_questions(QuestionState::Pending).await.is_err());
 
     // -------------------------- database -----------------------------------
     // sanity check: we do not have any questions for this event in db
-    let event_id = guest_url.path_segments().unwrap().next_back().unwrap();
     assert_eq!(d.event_questions(event_id).await.unwrap().count, 0);
 
     // ---------------- first guest (not a gentle person) window -------------

--- a/server/tests/e2e/utils.rs
+++ b/server/tests/e2e/utils.rs
@@ -102,6 +102,26 @@ impl Client {
             .await
     }
 
+    /// Ask a question.
+    ///
+    /// Internally, we locate the `Ask another question` button and fill in
+    /// the alerts with the question's text and signature (author's name or nickname).
+    /// The latter is optional: guest can ask questions anonymously.
+    pub(crate) async fn ask(&self, qtext: &str, qauthor: Option<&str>) -> Result<(), CmdError> {
+        self.wait_for_element(Locator::Id("ask-question-button"))
+            .await?
+            .click()
+            .await?;
+        self.send_alert_text(qtext).await?;
+        self.accept_alert().await?;
+        if let Some(name) = qauthor {
+            self.send_alert_text(name).await?;
+            self.accept_alert().await
+        } else {
+            self.dismiss_alert().await
+        }
+    }
+
     /// Awaits till questions' details are loaded and returns the list of questions.
     ///
     /// Internally, makes sure that the questions's details (text first of all)

--- a/server/tests/e2e/utils.rs
+++ b/server/tests/e2e/utils.rs
@@ -157,7 +157,7 @@ impl Client {
         self.find_all(Locator::Css(&question_item_selector)).await
     }
 
-    /// Creates a new Q&A session and returns a guest link.
+    /// Creates a new Q&A session and returns its ID and guest link.
     ///
     /// Internally, will navigate to the app's homepage, locate and click
     /// the "Open new Q&A session" button, then - in the event's page already -

--- a/server/tests/e2e/vote.rs
+++ b/server/tests/e2e/vote.rs
@@ -1,4 +1,4 @@
-use crate::utils::TestContext;
+use crate::utils::{QuestionState, TestContext};
 use fantoccini::Locator;
 
 async fn guest_asks_question_and_others_vote(
@@ -12,7 +12,7 @@ async fn guest_asks_question_and_others_vote(
     // ------------------------ host window ----------------------------------
     // host creates a new event
     let guest_url = h.create_event().await;
-    assert!(h.wait_for_pending_questions().await.unwrap().is_empty());
+    assert!(h.expect_questions(QuestionState::Pending).await.is_err());
 
     // ------------------------ first guest window -----------------------
     // first guest opens the link and ...
@@ -31,24 +31,19 @@ async fn guest_asks_question_and_others_vote(
     g1.send_alert_text(question_author).await.unwrap();
     g1.accept_alert().await.unwrap();
     // ... appears on the screen
-    assert!(g1
-        .wait_for_element(Locator::Css("#pending-questions article .question__text"))
-        .await
-        .unwrap()
+    let pending_questions = g1.expect_questions(QuestionState::Pending).await.unwrap();
+    assert_eq!(pending_questions.len(), 1);
+    assert!(pending_questions[0]
         .text()
         .await
         .unwrap()
         .to_lowercase()
         .contains(&question_text.to_lowercase()));
-    // we now know that question details have all been fetched
-    let question = g1
-        .wait_for_element(Locator::Css("#pending-questions article"))
-        .await
-        .unwrap();
+
     // note that the question will have one vote by default, meaning we are
     // upvoting our own question by default, and ...
     assert_eq!(
-        question
+        pending_questions[0]
             .find(Locator::Css("[data-votes]"))
             .await
             .unwrap()
@@ -64,7 +59,7 @@ async fn guest_asks_question_and_others_vote(
     // not something that the app guarantees and our next assertion is more for
     // demo purposes and we will show later on that other guest can upvote this
     // question without any hacks rather within the normal app flow
-    assert!(question
+    assert!(pending_questions[0]
         .find(Locator::Css(r#"button[data-action="upvote"]"#))
         .await
         .is_err());
@@ -73,9 +68,7 @@ async fn guest_asks_question_and_others_vote(
     // host can see the newly added question and also that there is one vote
     // for this question (the default one from the question's author)
     assert_eq!(
-        h.wait_for_element(Locator::Css("#pending-questions article"))
-            .await
-            .unwrap()
+        h.expect_questions(QuestionState::Pending).await.unwrap()[0]
             .find(Locator::Css("[data-votes]"))
             .await
             .unwrap()
@@ -88,41 +81,33 @@ async fn guest_asks_question_and_others_vote(
     // ------------------------ second guest window ----------------------
     // second guest sees the newly asked question and ...
     g2.goto(guest_url.as_str()).await.unwrap();
-    assert!(g2
-        // we are making sure this way the text content of the questions
-        // has been loaded rather than only the question item container
-        .wait_for_element(Locator::Css("#pending-questions article .question__text"))
-        .await
-        .unwrap()
+    let pending_questions = g2.expect_questions(QuestionState::Pending).await.unwrap();
+    assert_eq!(pending_questions.len(), 1);
+    assert!(pending_questions[0]
         .text()
         .await
         .unwrap()
         .to_lowercase()
         .contains(&question_text.to_lowercase()));
-    let question = g2
-        .wait_for_element(Locator::Css("#pending-questions article"))
-        .await
-        .unwrap();
-    let vote_count = question
-        .find(Locator::Css("[data-votes]"))
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
-    assert!(vote_count.contains("1"));
-    assert!(question
-        .text()
-        .await
-        .unwrap()
-        .to_lowercase()
-        .contains(&question_text.to_lowercase()));
+    assert_eq!(
+        pending_questions[0]
+            .find(Locator::Css("[data-votes]"))
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap(),
+        "1"
+    );
+
     // .. they upvote it
-    let upvote_button = question
+    pending_questions[0]
         .find(Locator::Css(r#"button[data-action="upvote"]"#))
         .await
+        .unwrap()
+        .click()
+        .await
         .unwrap();
-    upvote_button.click().await.unwrap();
 
     // we are giving the front-end some time to poll for question details changes
     // from the back-end, in this case the number of votes have changed; one could
@@ -132,7 +117,7 @@ async fn guest_asks_question_and_others_vote(
     // avoid flakiness plus it's not the optimistic update that we are testing here
     g2.wait_for_polling().await;
     assert_eq!(
-        question
+        pending_questions[0]
             .find(Locator::Css("[data-votes]"))
             .await
             .unwrap()
@@ -144,9 +129,7 @@ async fn guest_asks_question_and_others_vote(
 
     // ------------------------ first guest window -----------------------
     assert_eq!(
-        g1.wait_for_element(Locator::Css("#pending-questions article"))
-            .await
-            .unwrap()
+        g1.expect_questions(QuestionState::Pending).await.unwrap()[0]
             .find(Locator::Css("[data-votes]"))
             .await
             .unwrap()
@@ -158,12 +141,9 @@ async fn guest_asks_question_and_others_vote(
 
     // -------------------------- host window --------------------------
     // host can now also see there are 2 votes for this question
-    let question = h
-        .wait_for_element(Locator::Css("#pending-questions article"))
-        .await
-        .unwrap();
+    let pending_questions = h.expect_questions(QuestionState::Pending).await.unwrap();
     assert_eq!(
-        question
+        pending_questions[0]
             .find(Locator::Css("[data-votes]"))
             .await
             .unwrap()
@@ -172,17 +152,21 @@ async fn guest_asks_question_and_others_vote(
             .unwrap(),
         "2"
     );
+
     // and btw the host can also upvote this question (maybe for their future
     // self to remember which questions they wanted to answer - even if this
     // is not the most popular one)
-    let upvote_button = question
+    pending_questions[0]
         .find(Locator::Css(r#"button[data-action="upvote"]"#))
         .await
+        .unwrap()
+        .click()
+        .await
         .unwrap();
-    upvote_button.click().await.unwrap();
+
     g2.wait_for_polling().await;
     assert_eq!(
-        question
+        pending_questions[0]
             .find(Locator::Css("[data-votes]"))
             .await
             .unwrap()
@@ -197,9 +181,7 @@ async fn guest_asks_question_and_others_vote(
     // session voted for this question
     // ------------------------ first guest window -----------------------
     assert_eq!(
-        g1.wait_for_element(Locator::Css("#pending-questions article"))
-            .await
-            .unwrap()
+        g1.expect_questions(QuestionState::Pending).await.unwrap()[0]
             .find(Locator::Css("[data-votes]"))
             .await
             .unwrap()
@@ -208,11 +190,10 @@ async fn guest_asks_question_and_others_vote(
             .unwrap(),
         "3"
     );
+
     // ------------------------ second guest window -----------------------
     assert_eq!(
-        g2.wait_for_element(Locator::Css("#pending-questions article"))
-            .await
-            .unwrap()
+        g2.expect_questions(QuestionState::Pending).await.unwrap()[0]
             .find(Locator::Css("[data-votes]"))
             .await
             .unwrap()

--- a/server/tests/e2e/vote.rs
+++ b/server/tests/e2e/vote.rs
@@ -11,17 +11,16 @@ async fn guest_asks_question_and_others_vote(
 ) {
     // ------------------------ host window ----------------------------------
     // host creates a new event
-    let guest_url = h.create_event().await;
+    let (eid, url) = h.create_event().await;
     assert!(h.expect_questions(QuestionState::Pending).await.is_err());
 
     // -------------------------- database -----------------------------------
     // sanity check: we do not have any questions for this event in db
-    let event_id = guest_url.path_segments().unwrap().next_back().unwrap();
-    assert_eq!(d.event_questions(event_id).await.unwrap().count, 0);
+    assert_eq!(d.event_questions(eid).await.unwrap().count, 0);
 
     // ------------------------ first guest window -----------------------
     // first guest opens the link and asks a question, which ...
-    g1.goto(guest_url.as_str()).await.unwrap();
+    g1.goto(url.as_str()).await.unwrap();
     let (qtext, qauthor) = ("Are we web yet?", "Steve");
     g1.ask(qtext, Some(qauthor)).await.unwrap();
 
@@ -75,7 +74,7 @@ async fn guest_asks_question_and_others_vote(
 
     // ------------------------ second guest window ----------------------
     // second guest sees the newly asked question and ...
-    g2.goto(guest_url.as_str()).await.unwrap();
+    g2.goto(url.as_str()).await.unwrap();
     let pending = g2.expect_questions(QuestionState::Pending).await.unwrap();
     assert_eq!(pending.len(), 1);
     assert!(pending[0]

--- a/server/tests/e2e/vote.rs
+++ b/server/tests/e2e/vote.rs
@@ -16,7 +16,7 @@ async fn guest_asks_question_and_others_vote(
 
     // -------------------------- database -----------------------------------
     // sanity check: we do not have any questions for this event in db
-    assert_eq!(d.event_questions(eid).await.unwrap().count, 0);
+    assert_eq!(d.event_questions(&eid).await.unwrap().count, 0);
 
     // ------------------------ first guest window -----------------------
     // first guest opens the link and asks a question, which ...
@@ -196,6 +196,18 @@ async fn guest_asks_question_and_others_vote(
             .unwrap(),
         "3"
     );
+
+    // --------------------------- database ----------------------------------
+    let questions = d.event_questions(eid).await.unwrap();
+    assert_eq!(questions.count, 1);
+    let qid = questions.items().first().unwrap().get("id").unwrap();
+    let q = d.question_by_id(qid.to_owned()).await.unwrap();
+    let q = q.item().unwrap();
+    assert!(!q.get("hidden").unwrap().as_bool().unwrap());
+    assert!(q.get("answered").is_none());
+    assert_eq!(q.get("who").unwrap().as_s().unwrap(), qauthor);
+    assert_eq!(q.get("text").unwrap().as_s().unwrap(), qtext);
+    assert_eq!(q.get("votes").unwrap().as_n().unwrap(), "3");
 }
 
 mod tests {

--- a/server/tests/e2e/vote.rs
+++ b/server/tests/e2e/vote.rs
@@ -207,7 +207,7 @@ async fn guest_asks_question_and_others_vote(
     assert!(q.get("answered").is_none());
     assert_eq!(q.get("who").unwrap().as_s().unwrap(), qauthor);
     assert_eq!(q.get("text").unwrap().as_s().unwrap(), qtext);
-    assert_eq!(q.get("votes").unwrap().as_n().unwrap(), "3");
+    assert_eq!(q.get("votes").unwrap().as_n().unwrap(), "3"); // NB
 }
 
 mod tests {

--- a/server/tests/e2e/vote.rs
+++ b/server/tests/e2e/vote.rs
@@ -6,13 +6,18 @@ async fn guest_asks_question_and_others_vote(
         host: h,
         guest1: g1,
         guest2: g2,
-        ..
+        dynamo: d,
     }: TestContext,
 ) {
     // ------------------------ host window ----------------------------------
     // host creates a new event
     let guest_url = h.create_event().await;
     assert!(h.expect_questions(QuestionState::Pending).await.is_err());
+
+    // -------------------------- database -----------------------------------
+    // sanity check: we do not have any questions for this event in db
+    let event_id = guest_url.path_segments().unwrap().next_back().unwrap();
+    assert_eq!(d.event_questions(event_id).await.unwrap().count, 0);
 
     // ------------------------ first guest window -----------------------
     // first guest opens the link and asks a question, which ...


### PR DESCRIPTION
- addressing [thread](https://github.com/jonhoo/wewerewondering/pull/271#discussion_r2346011854)
- inspecting db at each test's end to make sure votes and hidden/answered status are persisted
- cleaning up a bit to try and make tests slim and more readable